### PR TITLE
Add methodology V for rectifier bridge experiment

### DIFF
--- a/Informe VI - Lab. Circuitos.tex
+++ b/Informe VI - Lab. Circuitos.tex
@@ -197,6 +197,32 @@ Se armó el circuito RC serie indicado en la guía práctica sobre un protoboard
     \caption{Simulación en el punto B}
     \label{fig:simulacion-rc-respuesta}
 \end{figure}
+
+\subsection{Metodología V: montaje del puente rectificador}
+Siguiendo la guía de laboratorio, se ensambló el circuito de puente de Graetz mostrado en la Figura~\ref{fig:rectificador-montaje}, utilizando el transformador reductor disponible para alimentar el arreglo de cuatro diodos y la resistencia de carga. Primero se conectó el osciloscopio a los nodos A y B, ubicados a la salida secundaria del transformador, con el fin de visualizar la señal senoidal de entrada. Posteriormente se reubicó la sonda en los puntos C y D, sobre la resistencia de carga, para observar la forma de onda rectificada y registrar los valores característicos solicitados en la práctica.
+
+Para completar el procedimiento se retiró temporalmente el condensador de filtrado, repitiendo la medición en los puntos C y D. Esto permitió comparar la ondulación de la señal con y sin el elemento de filtro, además de estimar la frecuencia correspondiente a la componente pulsante observada en el osciloscopio. Finalmente, se replicó el montaje en el software de simulación empleado durante la práctica, conservando los mismos parámetros de alimentación y carga. Las Figuras~\ref{fig:rectificador-simulacion-ab} y~\ref{fig:rectificador-simulacion-cd} recogen las gráficas exportadas de la simulación para los puntos A-B y C-D, respectivamente, lo que facilita contrastar la respuesta teórica con las mediciones experimentales.
+
+\begin{figure}[htbp]
+    \centering
+    \framebox[0.75\linewidth]{\rule{0pt}{3.5cm}}
+    \caption{Montaje del puente rectificador sobre protoboard.}
+    \label{fig:rectificador-montaje}
+\end{figure}
+
+\begin{figure}[htbp]
+    \centering
+    \includegraphics[width=0.75\linewidth]{Rectificador AB.jpg}
+    \caption{Simulación del voltaje en los puntos A-B del transformador.}
+    \label{fig:rectificador-simulacion-ab}
+\end{figure}
+
+\begin{figure}[htbp]
+    \centering
+    \includegraphics[width=0.75\linewidth]{Rectificador CD.jpg}
+    \caption{Simulación del voltaje rectificado en la carga (puntos C-D).}
+    \label{fig:rectificador-simulacion-cd}
+\end{figure}
 \section{Resultados}
 \subsection{Figura de ejemplo}
 


### PR DESCRIPTION
## Summary
- document the bridge rectifier procedure based on the oscilloscope lab guide
- add figure placeholders for the physical setup and simulation captures at nodes A-B and C-D

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df0da57640832e952a7e3153421aeb