### PR TITLE
Remove montage photo reference in methodology III

### DIFF
--- a/Informe VI - Lab. Circuitos.tex
+++ b/Informe VI - Lab. Circuitos.tex
@@ -131,13 +131,7 @@ Se registraron en la Tabla~\ref{tab:resultados-ac} los valores correspondientes 
 \end{table}
 
 \subsection{Metodología III: medición de frecuencia}
-Se conectó el generador de señales directamente al canal~1 del osciloscopio, tal como se ilustra en la Figura~\ref{fig:montaje-frecuencia}. A partir de esta conexión se fijaron los parámetros de la señal según lo indicado en la guía experimental: amplitud pico a pico de \SI{6}{\volt}, offset de \SI{0}{\volt} y desfase nulo. Posteriormente, se ajustó la base de tiempo del instrumento para conseguir una visualización estable de cada forma de onda.
-\begin{figure}[htbp]
-    \centering
-    \framebox[0.75\linewidth]{\rule{0pt}{3.5cm}}
-    \caption{Montaje empleado en la medición de frecuencia.}
-    \label{fig:montaje-frecuencia}
-\end{figure}
+Se conectó el generador de señales directamente al canal~1 del osciloscopio, manteniendo una disposición sencilla que facilitara la visualización de las formas de onda. A partir de esta conexión se fijaron los parámetros de la señal según lo indicado en la guía experimental: amplitud pico a pico de \SI{6}{\volt}, offset de \SI{0}{\volt} y desfase nulo. Posteriormente, se ajustó la base de tiempo del instrumento para conseguir una visualización estable de cada forma de onda.
 Con la ayuda del generador se configuraron las señales enlistadas en la Tabla~\ref{tab:frecuencia}, registrando en el osciloscopio tanto la base de tiempo seleccionada (tiempo/división) como el período resultante. Las formas de onda obtenidas se muestran en las Figuras~\ref{fig:frecuencia-senoidal-100hz}--\ref{fig:frecuencia-rampa-1k5hz}, lo que permite comparar la respuesta del equipo frente a cambios en la frecuencia y el tipo de señal.%
 \begin{table}[htbp]
     \centering


### PR DESCRIPTION
## Summary
- remove the placeholder figure for the frequency measurement montage
- update the accompanying description to avoid referencing the removed photo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df0f4850bc832e89e2b96ee45321ae